### PR TITLE
Speed up build by a whole minute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
+# Binaries
 build/
+
+# Objects
+*.o
+
+# Emacs files
+*~

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+CC=g++
+
+# Make the number of jobs equal the number of threads the CPU is capable of
+MAKEFLAGS := --jobs=$(shell nproc)
+
+# Compiler flags
+CFLAGS = -march=x86-64-v3 -shared -std=c++17 -O2 -fPIC -Werror -fno-exceptions -g
+
+# Linker flags
+LDFLAGS = -lSDL2 -lvulkan -lm -ldl  -g
+LDFLAGS += $(shell find build/ -name '*.a')
+
+# Our source files
+OBJ_FILES = $(shell find src/ -name '*.cpp' | sed -e "s/$$/.o/")
+
+OBJS = $(addprefix obj/, $(OBJ_FILES)) 
+
+# Binaries
+BIN = build/libvapo.so
+
+.PHONY: all clean debug
+
+#-------------------------------------------------------------------------------
+
+all: $(BIN)
+
+clean:
+	rm -f $(OBJS)
+	rm -f $(BIN)
+
+#-------------------------------------------------------------------------------
+
+$(BIN): $(OBJS)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+obj/%.cpp.o: %.cpp
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c -o $@ $<

--- a/build.sh
+++ b/build.sh
@@ -58,18 +58,8 @@ chmod +x build/attach.sh
 
 echo "Compiling skill issue"
 
-# compile it
-# this shit takes longer to compile than I want to admit
-# i shouldn't include the entire pluto and glew libraries
-# but it doesn't attach without them
-# fuck my life
-g++ -shared -fPIC \
-	$(find src -name "*.cpp") \
-	$(find build -name "*.a") \
-	$(find build/imgui -name "*.a") \
-	-o build/libvapo.so \
-	-O2 -std=c++17 -lSDL2 -lvulkan -lm -ldl \
-	-Werror -fno-exceptions -g -march=x86-64-v3
+# compile the cheat
+make # Note: This will echo
 
 # make .debug symbol file
 objcopy --only-keep-debug build/libvapo.so build/libvapo.debug


### PR DESCRIPTION
Hello, I was astonished when I saw it took **two minutes** to compile the hack + libraries on my machine.
This commit uses Makefile's multi-threading jobs to build only the hack itself faster, and it has reduced the build time by a whole minute on my computer. It does still inject, by the way.

Here are some images to prove it. 
On the left is my branch, and on the right is your main:

`Hack + Libraries`
<img width="1595" height="53" alt="Screenshot_20260227_162354" src="https://github.com/user-attachments/assets/c4f1e02c-68f0-4877-acf1-421ee81e2525" />

`Just the Hack`
<img width="1595" height="53" alt="Screenshot_20260227_162553" src="https://github.com/user-attachments/assets/8f544fe7-8321-4953-ba79-95803dc0806c" />

As well, Makefile will only build source files which have been modified, so that `11s` build time will be even lower when you need to build the hack after a minor change.

I also made some minor changes to the gitignore so it ignores other garbage data text editors or build systems might produce.